### PR TITLE
deploy bails early if release already exists

### DIFF
--- a/cmd/ranch/cmd/deploy.go
+++ b/cmd/ranch/cmd/deploy.go
@@ -71,6 +71,12 @@ var deployCmd = &cobra.Command{
 		appVersion, err := util.AppVersion(cmd)
 		util.Check(err)
 
+		exists, err := util.EcruReleaseExists(appName, appVersion)
+		util.Check(err)
+		if exists {
+			util.Die(fmt.Sprintf("release %s already exists.", appVersion))
+		}
+
 		imageName := util.DockerImageName(appName, appVersion)
 
 		if Build {

--- a/cmd/ranch/util/ecru.go
+++ b/cmd/ranch/util/ecru.go
@@ -41,6 +41,27 @@ func ecruClient() (*gorequest.SuperAgent, error) {
 	return request, nil
 }
 
+func EcruReleaseExists(appName, sha string) (exists bool, err error) {
+	client, err := ecruClient()
+
+	if err != nil {
+		return false, err
+	}
+
+	url := fmt.Sprintf("https://ecru.goodeggs.com/api/v1/projects/%s/releases/%s", appName, sha)
+	resp, _, errs := client.Get(url).End()
+
+	if len(errs) > 0 {
+		return false, errs[0]
+	} else if resp.StatusCode == 404 {
+		return false, nil
+	} else if resp.StatusCode == 200 {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("error fetching release info: HTTP %d", resp.StatusCode)
+}
+
 func EcruCreateRelease(appName, sha, convoxRelease string) error {
 
 	client, err := ecruClient()


### PR DESCRIPTION
previously we'd build the docker image and release it to convox before bailing at the last second when creating the release in Ecru fails.  now we'll check the release first, and bail early if it already exists.