### PR TITLE
deploy ignores a noop scale

### DIFF
--- a/cmd/ranch/cmd/deploy.go
+++ b/cmd/ranch/cmd/deploy.go
@@ -106,7 +106,7 @@ var deployCmd = &cobra.Command{
 		err = convoxDeploy(appName, appVersion, buildDir)
 		util.Check(err)
 
-		err = convoxScale(appName, config)
+		err = util.ConvoxScale(appName, config)
 		util.Check(err)
 
 	},
@@ -115,19 +115,6 @@ var deployCmd = &cobra.Command{
 func init() {
 	deployCmd.Flags().BoolVar(&Build, "build", true, "Build and push the Docker image")
 	RootCmd.AddCommand(deployCmd)
-}
-
-func convoxScale(appName string, config *util.RanchConfig) error {
-	var err error
-
-	for processName, processConfig := range config.Processes {
-		err = util.ConvoxScale(appName, processName, processConfig.Instances, processConfig.Memory)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func convoxDeploy(appName, appVersion, buildDir string) error {

--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -22,6 +22,14 @@ type RanchConfigProcess struct {
 
 type RanchConfigProcessMap map[string]RanchConfigProcess
 
+type RanchFormationEntry struct {
+	Balancer  string `json:"balancer"`
+	Instances int    `json:"instances"`
+	Memory    int    `json:"memory"`
+}
+
+type RanchFormation map[string]RanchFormationEntry
+
 type Process struct {
 	Id      string    `json:"id"`
 	App     string    `json:"app"`


### PR DESCRIPTION
When we deploy today, if the desired scale (instance count and memory) is the same as the existing scale, the deploy is successful but the CLI exits 1.  With this PR, we now check the existing scale and only scale if it does not match.
