### PR TITLE
fix ami docker volumes

### DIFF
--- a/ami/packer.json
+++ b/ami/packer.json
@@ -92,13 +92,12 @@
         "sudo mv {/home/ec2-user,/var/lib/collectd}/memory-available.sh",
         "sudo chmod 0755 /var/lib/collectd/memory-available.sh",
 
-        "# Reset cloud-init",
-        "sudo rm -rf /var/lib/cloud/{sem,instance,instances/*}",
+        "# Clear docker fs",
+        "sudo service docker stop",
+        "sudo rm -rf /var/lib/docker/*",
 
-        "# Remove all ECS execution traces added while running packer",
-        "sudo stop ecs 2> /dev/null || true",
-        "sudo docker rm ecs-agent 2> /dev/null || true",
-        "sudo rm -rf /var/log/ecs/* /var/lib/ecs/data/*"
+        "# Reset cloud-init",
+        "sudo rm -rf /var/lib/cloud/{sem,instance,instances/*}"
       ]
     }
   ]

--- a/ami/packer.json
+++ b/ami/packer.json
@@ -29,10 +29,6 @@
   ],
   "provisioners": [
     {
-      "type": "shell-local",
-      "command": "echo wait for scp to install; sleep 30"
-    },
-    {
       "type": "file",
       "source": "logspout-goodeggs.conf",
       "destination": "/home/ec2-user/logspout-goodeggs.conf"

--- a/ami/packer.json
+++ b/ami/packer.json
@@ -9,7 +9,7 @@
     "librato_email": null,
     "librato_token": null,
     "env": null,
-    "version": "{{isotime \"2006-01-02\"}}"
+    "version": "{{isotime \"20060102T150405\"}}"
   },
   "builders": [
     {

--- a/ami/user_data.sh
+++ b/ami/user_data.sh
@@ -1,6 +1,3 @@
 #!/bin/sh
 
-# NOTE: this exists because the ECS AMI does not include scp.
-# we can kill this and the hacky sleep 30 off once https://github.com/mitchellh/packer/pull/2504 is merged.
 
-yum install -y openssh-clients

--- a/ami/user_data.sh
+++ b/ami/user_data.sh
@@ -1,3 +1,21 @@
-#!/bin/sh
+#cloud-config
 
+# attempt to disable everything except ssh and the initial yum update
+
+cloud_init_modules:
+  - users-groups
+  - ssh
+
+cloud_config_modules:
+  - yum-configure
+  - yum-add-repo
+  - package-update-upgrade-install
+
+packages: []
+
+cloud_final_modules: []
+
+bootcmd: []
+
+runcmd: []
 


### PR DESCRIPTION
the ECS-optimized Amazon AMI uses cloud-init to set up various things, including devicemapper storage for docker.  with Convox 20160213224638, our old packer process broke down because (it seems) cloud-init was initializing docker storage once during the packer build, and then again during the "actual first boot."

this PR uses user-data to _almost_ disable cloud-init during the packer build so the first boot can be just that.

one catch was that docker is started during the packer build, and we need to `rm -rf /var/lib/docker/*` before we snapshot the AMI.  if we don't, docker will fail to start with storage-related errors on the "first boot."
