### PR TITLE
'ranch ps' shows sha

### DIFF
--- a/cmd/ranch/.goxc.json
+++ b/cmd/ranch/.goxc.json
@@ -5,7 +5,7 @@
 		"publish-github"
 	],
 	"BuildConstraints": "linux,amd64 darwin,amd64",
-	"PackageVersion": "1.0.4",
+	"PackageVersion": "1.0.5",
 	"TaskSettings": {
 		"publish-github": {
 			"owner": "goodeggs",

--- a/cmd/ranch/util/convox.go
+++ b/cmd/ranch/util/convox.go
@@ -330,10 +330,25 @@ func ConvoxPs(appName string) (Processes, error) {
 		return nil, err
 	}
 
+	shaMap, err := buildShaMap(appName)
+
+	if err != nil {
+		return nil, err
+	}
+
 	var ps Processes
 
 	for _, v := range convoxPs {
 		p := Process(v)
+
+		sha, ok := shaMap[p.Release]
+
+		if !ok {
+			p.Release = "convox:" + p.Release
+		} else {
+			p.Release = sha
+		}
+
 		ps = append(ps, p)
 	}
 


### PR DESCRIPTION
rather than displaying the convox release id (which we intend to hide), `ranch ps` now shows the git sha of the process' release.
