### PR TITLE
adds panic:scale command

### DIFF
--- a/cmd/ranch/cmd/panic_rollback.go
+++ b/cmd/ranch/cmd/panic_rollback.go
@@ -8,7 +8,7 @@ import (
 	"github.com/goodeggs/platform/cmd/ranch/util"
 )
 
-var panic_rollbackCmd = &cobra.Command{
+var panicRollbackCmd = &cobra.Command{
 	Use:   "panic:rollback <release>",
 	Short: "Revert to a previous release.",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -33,5 +33,5 @@ var panic_rollbackCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(panic_rollbackCmd)
+	RootCmd.AddCommand(panicRollbackCmd)
 }

--- a/cmd/ranch/cmd/panic_scale.go
+++ b/cmd/ranch/cmd/panic_scale.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/goodeggs/platform/cmd/ranch/util"
+)
+
+var memory int
+var count int
+
+var panicScaleCmd = &cobra.Command{
+	Use:   "panic:scale <process>",
+	Short: "Adjust the scale of a process.",
+	Run: func(cmd *cobra.Command, args []string) {
+		appName, err := util.AppName(cmd)
+		util.Check(err)
+
+		if len(args) != 1 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+
+		process := args[0]
+
+		err = util.ConvoxScaleProcess(appName, process, count, memory)
+		util.Check(err)
+	},
+}
+
+func init() {
+	panicScaleCmd.Flags().IntVar(&count, "count", -1, "Instance count")
+	panicScaleCmd.Flags().IntVar(&memory, "memory", -1, "Memory in MB")
+	RootCmd.AddCommand(panicScaleCmd)
+}


### PR DESCRIPTION
The Right Way(tm) to scale in the new world is to update the config and push to master.  Unfortunately, our pushes must clear Travis before they're picked up by Ecru and deployed/scaled.  As such, this will serve as a panic button to allow immediate change of scale.  Changes applied in this way will be overwritten by the next deploy.
