### PR TITLE
token auth

### DIFF
--- a/cmd/ranch/cmd/env.go
+++ b/cmd/ranch/cmd/env.go
@@ -10,26 +10,36 @@ import (
 var envCmd = &cobra.Command{
 	Use:   "env",
 	Short: "Print the application environment",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		config, err := util.LoadAppConfig(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		appName, err := util.AppName(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		if config.EnvId == "" {
-			util.Die("your config does not contain an env_id")
+			return fmt.Errorf("your config does not contain an env_id")
 		}
 
 		plaintext, err := util.EcruGetSecret(appName, config.EnvId)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		env, err := util.ParseEnv(plaintext)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		for key, value := range env {
 			fmt.Printf("%s=%s\n", key, value)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/ranch/cmd/init.go
+++ b/cmd/ranch/cmd/init.go
@@ -31,30 +31,40 @@ type yamlTemplateVars struct {
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize the .ranch.yaml file",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		appName, err := util.AppName(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		appDir, err := util.AppDir(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		appYaml := path.Join(appDir, ".ranch.yaml")
 		if _, err := os.Stat(appYaml); !os.IsNotExist(err) {
-			util.Die(".ranch.yaml already exists!")
+			return fmt.Errorf(".ranch.yaml already exists!")
 		}
 
 		tmpl, err := template.New(".ranch.yaml").Parse(yamlTemplate)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		vars := yamlTemplateVars{appName}
 		var buf bytes.Buffer
-		err = tmpl.Execute(&buf, vars)
-		util.Check(err)
+		if err = tmpl.Execute(&buf, vars); err != nil {
+			return err
+		}
 
-		err = ioutil.WriteFile(appYaml, buf.Bytes(), 0644)
-		util.Check(err)
+		if err = ioutil.WriteFile(appYaml, buf.Bytes(), 0644); err != nil {
+			return err
+		}
 
 		fmt.Println("generated .ranch.yaml -- check it now!")
+
+		return nil
 	},
 }
 

--- a/cmd/ranch/cmd/logs.go
+++ b/cmd/ranch/cmd/logs.go
@@ -10,12 +10,17 @@ import (
 var logsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Tail the application logs",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		appName, err := util.AppName(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
-		err = util.ConvoxLogs(appName, os.Stdout)
-		util.Check(err)
+		if err = util.ConvoxLogs(appName, os.Stdout); err != nil {
+			return err
+		}
+
+		return nil
 	},
 }
 

--- a/cmd/ranch/cmd/panic_rollback.go
+++ b/cmd/ranch/cmd/panic_rollback.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/goodeggs/platform/cmd/ranch/util"
@@ -11,24 +10,30 @@ import (
 var panicRollbackCmd = &cobra.Command{
 	Use:   "panic:rollback <release>",
 	Short: "Revert to a previous release.",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		appName, err := util.AppName(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		if len(args) == 0 {
 			cmd.Usage()
-			os.Exit(1)
+			return fmt.Errorf("usage")
 		}
 
 		appVersion := args[0]
 
-		err = util.ConvoxPromote(appName, appVersion)
-		util.Check(err)
+		if err = util.ConvoxPromote(appName, appVersion); err != nil {
+			return err
+		}
 
-		err = util.ConvoxWaitForStatus(appName, "running")
-		util.Check(err)
+		if err = util.ConvoxWaitForStatus(appName, "running"); err != nil {
+			return err
+		}
 
 		fmt.Println("WARNING: this rollback only affects your code and environment -- scale may be inconsistent.")
+
+		return nil
 	},
 }
 

--- a/cmd/ranch/cmd/panic_scale.go
+++ b/cmd/ranch/cmd/panic_scale.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"os"
+	"fmt"
 
 	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/goodeggs/platform/cmd/ranch/util"
@@ -13,19 +13,24 @@ var count int
 var panicScaleCmd = &cobra.Command{
 	Use:   "panic:scale <process>",
 	Short: "Adjust the scale of a process.",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		appName, err := util.AppName(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		if len(args) != 1 {
 			cmd.Usage()
-			os.Exit(1)
+			return fmt.Errorf("usage")
 		}
 
 		process := args[0]
 
-		err = util.ConvoxScaleProcess(appName, process, count, memory)
-		util.Check(err)
+		if err = util.ConvoxScaleProcess(appName, process, count, memory); err != nil {
+			return err
+		}
+
+		return nil
 	},
 }
 

--- a/cmd/ranch/cmd/ps.go
+++ b/cmd/ranch/cmd/ps.go
@@ -15,13 +15,17 @@ func init() {
 var psCmd = &cobra.Command{
 	Use:   "ps",
 	Short: "List an app's processes",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 
 		appName, err := util.AppName(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		ps, err := util.ConvoxPs(appName)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetBorder(false)
@@ -35,5 +39,7 @@ var psCmd = &cobra.Command{
 		}
 
 		table.Render()
+
+		return nil
 	},
 }

--- a/cmd/ranch/cmd/releases.go
+++ b/cmd/ranch/cmd/releases.go
@@ -11,12 +11,16 @@ import (
 var releasesCmd = &cobra.Command{
 	Use:   "releases",
 	Short: "List releases",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		appName, err := util.AppName(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		releases, err := util.ConvoxReleases(appName)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetBorder(false)
@@ -30,6 +34,8 @@ var releasesCmd = &cobra.Command{
 		}
 
 		table.Render()
+
+		return nil
 	},
 }
 

--- a/cmd/ranch/cmd/root.go
+++ b/cmd/ranch/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/viper"
+	"github.com/goodeggs/platform/cmd/ranch/util"
 )
 
 var cfgFile string
@@ -29,20 +30,19 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ranch.yaml)")
 	RootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	RootCmd.PersistentFlags().StringVarP(&App, "app", "a", "", "application name (defaults to CWD)")
 }
 
 func initConfig() {
-	if cfgFile != "" { // enable ability to specify config file via flag
-		viper.SetConfigFile(cfgFile)
+	viper.SetEnvPrefix("ranch")
+	viper.SetDefault("endpoint", "https://ranch-api.goodeggs.com")
+	viper.BindEnv("endpoint")
+	viper.BindEnv("token")
+
+	if err := util.RanchLoadSettings(); err != nil {
+		fmt.Println("error trying to authenticate with ranch - did you set RANCH_TOKEN?")
+		fmt.Println(err)
+		os.Exit(1)
 	}
-
-	viper.SetConfigName(".ranch") // name of config file (without extension)
-	viper.AddConfigPath("$HOME")  // adding home directory as first search path
-	viper.AutomaticEnv()          // read in environment variables that match
-
-	// If a config file is found, read it in.
-	viper.ReadInConfig()
 }

--- a/cmd/ranch/cmd/root.go
+++ b/cmd/ranch/cmd/root.go
@@ -32,6 +32,8 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	RootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	RootCmd.PersistentFlags().StringVarP(&App, "app", "a", "", "application name (defaults to CWD)")
+	RootCmd.SilenceUsage = true
+	RootCmd.SilenceErrors = true
 }
 
 func initConfig() {

--- a/cmd/ranch/cmd/run.go
+++ b/cmd/ranch/cmd/run.go
@@ -12,17 +12,22 @@ import (
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run a one-off command",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		appName, err := util.AppName(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		process := "web"
 		command := strings.Join(args, " ")
 
 		exitCode, err := runAttached(appName, process, command)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		os.Exit(exitCode)
+		return nil
 	},
 }
 

--- a/cmd/ranch/cmd/run_detached.go
+++ b/cmd/ranch/cmd/run_detached.go
@@ -10,15 +10,20 @@ import (
 var runDetachedCmd = &cobra.Command{
 	Use:   "run:detached",
 	Short: "Run a detached one-off command",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		appName, err := util.AppName(cmd)
-		util.Check(err)
+		if err != nil {
+			return err
+		}
 
 		process := "web"
 		command := strings.Join(args, " ")
 
-		err = util.ConvoxRunDetached(appName, process, command)
-		util.Check(err)
+		if err = util.ConvoxRunDetached(appName, process, command); err != nil {
+			return err
+		}
+
+		return nil
 	},
 }
 

--- a/cmd/ranch/util/common.go
+++ b/cmd/ranch/util/common.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/parnurzeal/gorequest"
+)
+
+func noRedirects(req gorequest.Request, via []gorequest.Request) error {
+	return fmt.Errorf("refusing to follow redirect")
+}
+
+func jsonClient() *gorequest.SuperAgent {
+	return gorequest.New().
+		RedirectPolicy(noRedirects).
+		Set("Accept", "application/json").
+		Set("Content-Type", "application/json")
+}

--- a/cmd/ranch/util/ecru.go
+++ b/cmd/ranch/util/ecru.go
@@ -23,20 +23,13 @@ type EcruSecret struct {
 	Id string `json:"_id"`
 }
 
-func noRedirects(req gorequest.Request, via []gorequest.Request) error {
-	return fmt.Errorf("refusing to follow redirect")
-}
-
 func ecruClient() (*gorequest.SuperAgent, error) {
 	if !viper.IsSet("convox.password") {
 		return nil, fmt.Errorf("must set 'convox.password' in $HOME/.ranch.yaml")
 	}
 
-	request := gorequest.New().
-		RedirectPolicy(noRedirects).
-		SetBasicAuth(viper.GetString("convox.password"), "x-auth-token").
-		Set("Accept", "application/json").
-		Set("Content-Type", "application/json")
+	request := jsonClient().
+		SetBasicAuth(viper.GetString("convox.password"), "x-auth-token")
 
 	return request, nil
 }


### PR DESCRIPTION
in getting ecru able to deploy to ranch, it became obvious it was time to add a ranch-api server to the mix.  mainly it was an ever-growing `~/.ranch.yaml` file with lots of secrets in it that drove me here.  so now ranch-api (which is secured by one shared auth token for now) will return all the secrets necessary to do deploys.

this also sets me up for moving more functionality out of the `ranch` CLI and into the api server.

once I release this new version of the ranch CLI (1.4.0), you'll need to set `RANCH_TOKEN` in your local env, which will be in 1password.  you should also delete `~/.ranch.yaml` at that time.

/cc @serhalp @demands 