### PR TITLE
better hostname

### DIFF
--- a/ami/collectd.conf
+++ b/ami/collectd.conf
@@ -1,5 +1,3 @@
-Hostname %HOSTNAME%
-FQDNLookup false
 Interval 60
 
 LoadPlugin syslog

--- a/ami/collectd.sysconfig
+++ b/ami/collectd.sysconfig
@@ -1,1 +1,0 @@
-sed -i -- "/^Hostname/c\Hostname \"aws.%ENV%.$(curl -s http://169.254.169.254/latest/meta-data/instance-id)\"" /etc/collectd.conf

--- a/ami/goodeggs-hostname.conf
+++ b/ami/goodeggs-hostname.conf
@@ -1,0 +1,19 @@
+#!upstart
+
+start on runlevel [2345]
+
+task
+
+respawn
+respawn limit unlimited
+
+script
+  region=$(curl -sfm1 http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\w$//')
+  instanceId=$(curl -sfm1 http://169.254.169.254/latest/meta-data/instance-id)
+  hostname="${instanceId}"
+  fqdn="${hostname}.${region}.aws.%ENV%.goodeggs.com"
+  sed -i "/^HOSTNAME=/c\HOSTNAME=${fqdn}" /etc/sysconfig/network
+  sed -i "/^127.0.0.1[[:space:]]/c\127.0.0.1 ${fqdn} ${hostname} localhost localhost.localdomain" /etc/hosts
+  exec hostname "$fqdn"
+end script
+

--- a/ami/logspout-goodeggs.conf
+++ b/ami/logspout-goodeggs.conf
@@ -12,11 +12,12 @@ pre-start script
   exec >"/tmp/$UPSTART_JOB"
   echo "TOKEN=$(cat /etc/logspout-goodeggs/token)"
   echo "IMAGE=$(cat /etc/logspout-goodeggs/image)"
+  echo "HOST=$(hostname)"
 end script
 
 script
   . "/tmp/$UPSTART_JOB"
-  exec docker run -a STDOUT -a STDERR --sig-proxy -e LOGSPOUT=ignore -e SUMO_HTTP_TOKEN="$TOKEN" -v /var/run/docker.sock:/tmp/docker.sock "$IMAGE"
+  exec docker run -a STDOUT -a STDERR --sig-proxy -e LOGSPOUT=ignore -e SUMO_HTTP_TOKEN="$TOKEN" -e SUMO_HOST="$HOST" -v /var/run/docker.sock:/tmp/docker.sock "$IMAGE"
 end script
 
 post-start script

--- a/ami/packer.json
+++ b/ami/packer.json
@@ -4,7 +4,7 @@
     "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_security_token": "{{env `AWS_SECURITY_TOKEN`}}",
     "aws_region": "{{env `AWS_DEFAULT_REGION`}}",
-    "logspout_tag": "latest",
+    "logspout_tag": "ea282b6",
     "logspout_token": null,
     "librato_email": null,
     "librato_token": null,

--- a/ami/packer.json
+++ b/ami/packer.json
@@ -30,6 +30,11 @@
   "provisioners": [
     {
       "type": "file",
+      "source": "goodeggs-hostname.conf",
+      "destination": "/home/ec2-user/goodeggs-hostname.conf"
+    },
+    {
+      "type": "file",
       "source": "logspout-goodeggs.conf",
       "destination": "/home/ec2-user/logspout-goodeggs.conf"
     },
@@ -66,6 +71,9 @@
     {
       "type": "shell",
       "inline": [
+        "echo '# Install goodeggs-hostname.conf'",
+        "sudo mv {/home/ec2-user,/etc/init}/goodeggs-hostname.conf",
+
         "echo '# Setup /etc/logspout-goodeggs'",
         "sudo mkdir -p /etc/logspout-goodeggs",
         "echo 'goodeggs/logspout-goodeggs:{{user `logspout_tag`}}' | sudo dd of=/etc/logspout-goodeggs/image",

--- a/ami/packer.json
+++ b/ami/packer.json
@@ -50,11 +50,6 @@
     },
     {
       "type": "file",
-      "source": "collectd.sysconfig",
-      "destination": "/home/ec2-user/collectd.sysconfig"
-    },
-    {
-      "type": "file",
       "source": "memory-available.sh",
       "destination": "/home/ec2-user/memory-available.sh"
     },
@@ -73,6 +68,7 @@
       "inline": [
         "echo '# Install goodeggs-hostname.conf'",
         "sudo mv {/home/ec2-user,/etc/init}/goodeggs-hostname.conf",
+        "sudo sed -i -- 's/%ENV%/{{user `env`}}/' /etc/init/goodeggs-hostname.conf",
 
         "echo '# Setup /etc/logspout-goodeggs'",
         "sudo mkdir -p /etc/logspout-goodeggs",
@@ -97,8 +93,6 @@
         "sudo sed -i -- 's/%LIBRATO_EMAIL%/{{user `librato_email`}}/' /etc/collectd.conf",
         "sudo sed -i -- 's/%LIBRATO_TOKEN%/{{user `librato_token`}}/' /etc/collectd.conf",
         "sudo chmod 0600 /etc/collectd.conf",
-        "sudo mv /home/ec2-user/collectd.sysconfig /etc/sysconfig/collectd",
-        "sudo sed -i -- 's/%ENV%/{{user `env`}}/' /etc/sysconfig/collectd",
         "sudo mkdir -p /var/lib/collectd",
         "sudo mv {/home/ec2-user,/var/lib/collectd}/memory-available.sh",
         "sudo chmod 0755 /var/lib/collectd/memory-available.sh",

--- a/logspout-goodeggs/start
+++ b/logspout-goodeggs/start
@@ -5,4 +5,9 @@ if [ "${SUMO_HTTP_TOKEN}z" == "z" ]; then
   exit 1
 fi
 
-exec /bin/logspout sumo://${SUMO_HTTP_TOKEN}/
+if [ "${SUMO_HOST}z" == "z" ]; then
+  >&2 echo "refusing to start logspout: \$SUMO_HOST is not set."
+  exit 1
+fi
+
+exec /bin/logspout sumo://${SUMO_HTTP_TOKEN}/?host=${SUMO_HOST}


### PR DESCRIPTION
It's been a little tricky for me to trace things through AWS console, Librato, Sumo, ranch.  This PR ensures a consistent, useful hostname is set on our Convox instances.  `<instance-id>.<region>.aws.<env>.goodeggs.com`, eg `i-4e8a3bc9.us-east-1.aws.dev.goodeggs.com`.  This hostname is then used in collectd (which puts system metrics in Librato), and in logspout (which puts docker container logs in Sumo).

Planned follow-on work:
[] add the SumoLogic agent to collect system logs (eg `/var/log/*`)
[] setup [aws-name-server](https://github.com/ConradIrwin/aws-name-server) so we can actually resolve these great hostnames

Caveat: the AWS CloudWatch integration with Librato sends its own hostnames and we have no control over them.  I think this is reason to depend on those metrics as little as possible, which we already do.  With a little intuition, you can map the hostnames it provides to the ones described above.
