### PR TITLE
env on ranch api

### DIFF
--- a/cmd/ranch/cmd/deploy.go
+++ b/cmd/ranch/cmd/deploy.go
@@ -104,7 +104,7 @@ var deployCmd = &cobra.Command{
 
 		imageNameWithTag := strings.Join([]string{config.ImageName, appVersion}, ":")
 
-		exists, err := util.EcruReleaseExists(config.AppName, appVersion)
+		exists, err := util.RanchReleaseExists(config.AppName, appVersion)
 		if err != nil {
 			return err
 		} else if exists {

--- a/cmd/ranch/cmd/deploy.go
+++ b/cmd/ranch/cmd/deploy.go
@@ -131,7 +131,7 @@ var deployCmd = &cobra.Command{
 
 		var env map[string]string
 		if config.EnvId != "" {
-			plaintext, err := util.EcruGetSecret(appName, config.EnvId)
+			plaintext, err := util.RanchGetSecret(appName, config.EnvId)
 			if err != nil {
 				return err
 			}

--- a/cmd/ranch/cmd/deploy.go
+++ b/cmd/ranch/cmd/deploy.go
@@ -170,7 +170,7 @@ func convoxDeploy(appName, appVersion, buildDir string) error {
 		return err
 	}
 
-	if err = util.EcruCreateRelease(appName, appVersion, releaseId); err != nil {
+	if err = util.RanchCreateRelease(appName, appVersion, releaseId); err != nil {
 		return err
 	}
 

--- a/cmd/ranch/cmd/env.go
+++ b/cmd/ranch/cmd/env.go
@@ -25,7 +25,7 @@ var envCmd = &cobra.Command{
 			return fmt.Errorf("your config does not contain an env_id")
 		}
 
-		plaintext, err := util.EcruGetSecret(appName, config.EnvId)
+		plaintext, err := util.RanchGetSecret(appName, config.EnvId)
 		if err != nil {
 			return err
 		}

--- a/cmd/ranch/cmd/env_set.go
+++ b/cmd/ranch/cmd/env_set.go
@@ -68,7 +68,7 @@ var envSetCmd = &cobra.Command{
 			data += fmt.Sprintf("%s=%s\n", k, v)
 		}
 
-		envId, err := util.EcruCreateSecret(appName, data)
+		envId, err := util.RanchCreateSecret(appName, data)
 		if err != nil {
 			return err
 		}

--- a/cmd/ranch/cmd/env_unset.go
+++ b/cmd/ranch/cmd/env_unset.go
@@ -81,7 +81,7 @@ var envUnsetCmd = &cobra.Command{
 			data += fmt.Sprintf("%s=%s\n", k, v)
 		}
 
-		envId, err := util.EcruCreateSecret(appName, data)
+		envId, err := util.RanchCreateSecret(appName, data)
 		if err != nil {
 			return err
 		}

--- a/cmd/ranch/util/convox.go
+++ b/cmd/ranch/util/convox.go
@@ -370,7 +370,7 @@ func ConvoxWaitForStatus(appName, status string) error {
 	}
 }
 
-func ConvoxPs(appName string) (Processes, error) {
+func ConvoxPs(appName string) ([]RanchProcess, error) {
 	client, err := convoxClient()
 
 	if err != nil {
@@ -389,10 +389,10 @@ func ConvoxPs(appName string) (Processes, error) {
 		return nil, err
 	}
 
-	var ps Processes
+	var ps []RanchProcess
 
 	for _, v := range convoxPs {
-		p := Process(v)
+		p := RanchProcess(v)
 
 		sha, ok := shaMap[p.Release]
 

--- a/cmd/ranch/util/convox.go
+++ b/cmd/ranch/util/convox.go
@@ -25,7 +25,7 @@ func convoxClient() (*client.Client, error) {
 	return client.New(host, password, version), nil
 }
 
-func ConvoxReleases(appName string) (Releases, error) {
+func ConvoxReleases(appName string) ([]RanchRelease, error) {
 	client, err := convoxClient()
 
 	if err != nil {
@@ -50,7 +50,7 @@ func ConvoxReleases(appName string) (Releases, error) {
 		return nil, err
 	}
 
-	var releases Releases
+	var releases []RanchRelease
 
 	for _, convoxRelease := range convoxReleases {
 		status := ""
@@ -65,7 +65,7 @@ func ConvoxReleases(appName string) (Releases, error) {
 			continue
 		}
 
-		release := Release{
+		release := RanchRelease{
 			Id:      appVersion,
 			App:     appName,
 			Created: convoxRelease.Created,
@@ -409,7 +409,7 @@ func ConvoxPs(appName string) (Processes, error) {
 }
 
 func buildShaMap(appName string) (map[string]string, error) {
-	ecruReleases, err := EcruReleases(appName)
+	ranchReleases, err := RanchReleases(appName)
 
 	if err != nil {
 		return nil, err
@@ -417,23 +417,23 @@ func buildShaMap(appName string) (map[string]string, error) {
 
 	shaMap := make(map[string]string)
 
-	for _, ecruRelease := range ecruReleases {
-		shaMap[ecruRelease.ConvoxRelease] = ecruRelease.Sha
+	for _, ranchRelease := range ranchReleases {
+		shaMap[ranchRelease.ConvoxRelease] = ranchRelease.Id
 	}
 
 	return shaMap, nil
 }
 
 func getConvoxRelease(appName, appVersion string) (releaseId string, err error) {
-	ecruReleases, err := EcruReleases(appName)
+	ranchReleases, err := RanchReleases(appName)
 
 	if err != nil {
 		return "", err
 	}
 
-	for _, ecruRelease := range ecruReleases {
-		if ecruRelease.Sha == appVersion {
-			return ecruRelease.ConvoxRelease, nil
+	for _, ranchRelease := range ranchReleases {
+		if ranchRelease.Id == appVersion {
+			return ranchRelease.ConvoxRelease, nil
 		}
 	}
 

--- a/cmd/ranch/util/ecru.go
+++ b/cmd/ranch/util/ecru.go
@@ -42,27 +42,6 @@ func ecruClient() (*gorequest.SuperAgent, error) {
 	return request, nil
 }
 
-func EcruReleaseExists(appName, sha string) (exists bool, err error) {
-	client, err := ecruClient()
-
-	if err != nil {
-		return false, err
-	}
-
-	url := fmt.Sprintf("/projects/%s/releases/%s", appName, sha)
-	resp, _, errs := client.Get(ecruUrl(url)).End()
-
-	if len(errs) > 0 {
-		return false, errs[0]
-	} else if resp.StatusCode == 404 {
-		return false, nil
-	} else if resp.StatusCode == 200 {
-		return true, nil
-	}
-
-	return false, fmt.Errorf("error fetching release info: HTTP %d", resp.StatusCode)
-}
-
 func EcruCreateRelease(appName, sha, convoxRelease string) error {
 
 	client, err := ecruClient()

--- a/cmd/ranch/util/ecru.go
+++ b/cmd/ranch/util/ecru.go
@@ -42,41 +42,6 @@ func ecruClient() (*gorequest.SuperAgent, error) {
 	return request, nil
 }
 
-func EcruCreateRelease(appName, sha, convoxRelease string) error {
-
-	client, err := ecruClient()
-
-	if err != nil {
-		return err
-	}
-
-	pathname := fmt.Sprintf("/projects/%s/releases", appName)
-	reqBody := fmt.Sprintf(`{"sha":"%s","convoxRelease":"%s"}`, sha, convoxRelease)
-
-	resp, body, errs := client.Post(ecruUrl(pathname)).Send(reqBody).End()
-
-	if len(errs) > 0 {
-		return errs[0]
-	}
-
-	makeError := func(statusCode int, message string) error {
-		return fmt.Errorf("Error creating Ecru release [HTTP %d]: %s", statusCode, message)
-	}
-
-	switch resp.StatusCode {
-	case 201:
-		return nil
-	case 400:
-		var ecruError EcruError
-		err := json.Unmarshal([]byte(body), &ecruError)
-		if err == nil {
-			return makeError(resp.StatusCode, ecruError.Message)
-		}
-	}
-
-	return makeError(resp.StatusCode, body)
-}
-
 func EcruReleases(appName string) ([]EcruRelease, error) {
 
 	client, err := ecruClient()

--- a/cmd/ranch/util/ecru.go
+++ b/cmd/ranch/util/ecru.go
@@ -10,17 +10,6 @@ import (
 	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/viper"
 )
 
-type EcruError struct {
-	Message string `json:"error"`
-}
-
-type EcruRelease struct {
-	Id            string `json:"_id"`
-	ProjectId     string `json:"project"`
-	ConvoxRelease string `json:"convoxRelease"`
-	Sha           string `json:"sha"`
-}
-
 type EcruSecret struct {
 	Id string `json:"_id"`
 }
@@ -40,36 +29,6 @@ func ecruClient() (*gorequest.SuperAgent, error) {
 		SetBasicAuth(viper.GetString("convox.password"), "x-auth-token")
 
 	return request, nil
-}
-
-func EcruReleases(appName string) ([]EcruRelease, error) {
-
-	client, err := ecruClient()
-
-	if err != nil {
-		return nil, err
-	}
-
-	pathname := fmt.Sprintf("/projects/%s/releases", appName)
-
-	resp, body, errs := client.Get(ecruUrl(pathname)).End()
-
-	if len(errs) > 0 {
-		return nil, errs[0]
-	}
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Error fetching releases from Ecru: status code %d", resp.StatusCode)
-	}
-
-	var ecruReleases []EcruRelease
-	err = json.Unmarshal([]byte(body), &ecruReleases)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return ecruReleases, nil
 }
 
 func EcruGetSecret(appName, secretId string) (plaintext string, err error) {

--- a/cmd/ranch/util/env.go
+++ b/cmd/ranch/util/env.go
@@ -12,7 +12,7 @@ func EnvGet(appName, envId string) (env map[string]string, err error) {
 		return env, nil
 	}
 
-	plaintext, err := EcruGetSecret(appName, envId)
+	plaintext, err := RanchGetSecret(appName, envId)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -173,6 +173,23 @@ func RanchGetSecret(appName, secretId string) (string, error) {
 	return string(plaintextBytes), nil
 }
 
+func RanchReleaseExists(appName, sha string) (exists bool, err error) {
+	client := ranchClient()
+
+	url := fmt.Sprintf("/apps/%s/releases/%s", appName, sha)
+	resp, _, errs := client.Get(ranchUrl(url)).End()
+
+	if len(errs) > 0 {
+		return false, errs[0]
+	} else if resp.StatusCode == 404 {
+		return false, nil
+	} else if resp.StatusCode == 200 {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("error fetching release info: HTTP %d", resp.StatusCode)
+}
+
 func RanchCreateSecret(appName, plaintext string) (secretId string, err error) {
 
 	client := ranchClient()

--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -150,7 +150,7 @@ func RanchGetSecret(appName, secretId string) (string, error) {
 
 	client := ranchClient()
 
-	pathname := fmt.Sprintf("/apps/%s/secrets/%s", appName, secretId)
+	pathname := fmt.Sprintf("/v1/apps/%s/secrets/%s", appName, secretId)
 
 	resp, body, errs := client.Get(ranchUrl(pathname)).End()
 
@@ -177,7 +177,7 @@ func RanchCreateSecret(appName, plaintext string) (secretId string, err error) {
 
 	client := ranchClient()
 
-	pathname := fmt.Sprintf("/apps/%s/secrets", appName)
+	pathname := fmt.Sprintf("/v1/apps/%s/secrets", appName)
 
 	secret := RanchApiSecret{
 		Content: base64.StdEncoding.EncodeToString([]byte(plaintext)),

--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -54,7 +54,7 @@ type RanchFormationEntry struct {
 
 type RanchFormation map[string]RanchFormationEntry
 
-type Process struct {
+type RanchProcess struct {
 	Id      string    `json:"id"`
 	App     string    `json:"app"`
 	Command string    `json:"command"`
@@ -67,8 +67,6 @@ type Process struct {
 	Memory  float64   `json:"memory"`
 	Started time.Time `json:"started"`
 }
-
-type Processes []Process
 
 type RanchRelease struct {
 	Id      string    `json:"id"`


### PR DESCRIPTION
storing ranch secrets and releases in Ecru was convenient because it existed.  now that ranch-api exists and I've ported the secrets API, make the ranch CLI use it instead of Ecru.

---

## release plan

- [x] merge goodeggs/ranch-api#5
- [x] run load data script
- [x] test CLI dev build against ranch (secrets, releases create, exists, list)
- [ ] merge this
- [ ] release CLI
- [ ] bump CLI version in heroku-buildpack-ecru
- [ ] merge goodeggs/ecru#64 to remove secrets & releases API in Ecru
- [ ] pause Ecru _no builds during rollout_
- [ ] copy data from ecru & run fix script in ranch-api
- [ ] push Ecru to remove APIs & get new CLI _no new ecru data at this point_
- [ ] copy data from ecru & run fix script in ranch-api
- [ ] unpause Ecru
