### PR TITLE
Cron

### DIFF
--- a/cmd/ranch/cmd/deploy.go
+++ b/cmd/ranch/cmd/deploy.go
@@ -69,6 +69,8 @@ run:
   command: sh -c 'while true; do echo this process should not be running; sleep 300; done'
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
+  labels:
+{{ range $k, $v := $.Config.Cron }}{{ printf "    - convox.cron.%s=%s\n" $k $v }}{{ end }}
   environment:
 {{ range $k, $v := $.Environment }}{{ printf "    - %s=%s\n" $k $v }}{{ end }}
 `))

--- a/cmd/ranch/cmd/lint.go
+++ b/cmd/ranch/cmd/lint.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/goodeggs/platform/cmd/ranch/util"
+)
+
+var lintCmd = &cobra.Command{
+	Use:   "lint",
+	Short: "Lint a ranch config",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		config, err := util.LoadAppConfig(cmd)
+		if err != nil {
+			return err
+		}
+
+		errs := util.RanchValidateConfig(config)
+
+		if len(errs) == 0 {
+			fmt.Println("valid")
+			return nil
+		}
+
+		for _, err := range errs {
+			fmt.Println(err.Error())
+		}
+		return fmt.Errorf("ranch config had errors")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(lintCmd)
+}

--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -31,10 +31,10 @@ type RanchApiSecret struct {
 }
 
 type RanchConfig struct {
-	AppName   string                `json:"name"`
-	ImageName string                `json:"image_name"`
-	EnvId     string                `json:"env_id"`
-	Processes RanchConfigProcessMap `json:"processes"`
+	AppName   string                        `json:"name"`
+	ImageName string                        `json:"image_name"`
+	EnvId     string                        `json:"env_id"`
+	Processes map[string]RanchConfigProcess `json:"processes"`
 }
 
 type RanchConfigProcess struct {
@@ -43,8 +43,6 @@ type RanchConfigProcess struct {
 	Instances int    `json:"instances"` // deprecated
 	Memory    int    `json:"memory"`
 }
-
-type RanchConfigProcessMap map[string]RanchConfigProcess
 
 type RanchFormationEntry struct {
 	Balancer string `json:"balancer"`


### PR DESCRIPTION
Cron!  Scheduled Jobs!

I got to cheat on this one for now since [Convox implemented it](https://convox.com/docs/scheduled-tasks/) before I got to it.  It is implemented as a scheduled AWS Lambda function.  This function starts a detached run of the command you specify on the schedule you specify.  As such, it is best-effort (like Heroku Scheduler) but has no fancy overrun protection (unlike Heroku Scheduler) ... which means you _absolutely_ should adhere to our existing best practice of assuming there may be more than one running.

## Usage

Add a new `cron` section to your ranch yaml file.

```
cron:
  helloworld: "*/10 * * * ? echo hello world"
```

And as a refresher, the cron format is:
```
.---------------- minute (0 - 59)
|  .------------- hour (0 - 23)
|  |  .---------- day-of-month (1 - 31)
|  |  |  .------- month (1 - 12) OR JAN,FEB,MAR,APR ...
|  |  |  |  .---- day-of-week (0 - 6) (Sunday=0 or 7) OR SUN,MON,TUE,WED,THU,FRI,SAT
|  |  |  |  |
*  *  *  *  *
```
