### PR TITLE
don't strip "comments" in util.ParseEnv

### DIFF
--- a/cmd/ranch/util/env.go
+++ b/cmd/ranch/util/env.go
@@ -52,29 +52,6 @@ func parseLine(line string) (key string, value string, err error) {
 		return
 	}
 
-	// ditch the comments (but keep quoted hashes)
-	if strings.Contains(line, "#") {
-		segmentsBetweenHashes := strings.Split(line, "#")
-		quotesAreOpen := false
-		var segmentsToKeep []string
-		for _, segment := range segmentsBetweenHashes {
-			if strings.Count(segment, "\"") == 1 || strings.Count(segment, "'") == 1 {
-				if quotesAreOpen {
-					quotesAreOpen = false
-					segmentsToKeep = append(segmentsToKeep, segment)
-				} else {
-					quotesAreOpen = true
-				}
-			}
-
-			if len(segmentsToKeep) == 0 || quotesAreOpen {
-				segmentsToKeep = append(segmentsToKeep, segment)
-			}
-		}
-
-		line = strings.Join(segmentsToKeep, "#")
-	}
-
 	// now split key from value
 	splitString := strings.SplitN(line, "=", 2)
 


### PR DESCRIPTION
the function I borrowed to parse env variables included comment handling, which broke env variables with values that included `#`, eg `FOO='bar#baz'` became `FOO=bar`.

this PR strips comment handling as we don't need or expect it.

/cc @jhob @sylspren @demands 