### PR TITLE
set convox ELB timeout to 60 seconds

### DIFF
--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -67,6 +67,7 @@ var dockerComposeTemplate = template.Must(template.New("docker-compose").Parse(`
   {{ if eq $name "web" }}
   labels:
     - convox.port.443.protocol=https
+    - convox.idle.timeout=60
   ports:
     - 443:3000
   {{ end }}


### PR DESCRIPTION
ELBs throw 504s if not allowed to control the keep-alive state of
backend sockets.  Since Node defaults to 120, we'll set the ELBs
to 60.