### PR TITLE
concise logging

### DIFF
--- a/cmd/ranch/cmd/panic_rollback.go
+++ b/cmd/ranch/cmd/panic_rollback.go
@@ -23,13 +23,7 @@ var panicRollbackCmd = &cobra.Command{
 
 		appVersion := args[0]
 
-		fmt.Printf("promoting release %s", appVersion)
-
 		if err = util.ConvoxPromote(appName, appVersion); err != nil {
-			return err
-		}
-
-		if err = util.ConvoxWaitForStatus(appName, "running"); err != nil {
 			return err
 		}
 

--- a/cmd/ranch/cmd/root.go
+++ b/cmd/ranch/cmd/root.go
@@ -10,7 +10,6 @@ import (
 )
 
 var App string
-var Verbose bool
 var Version string
 
 var RootCmd = &cobra.Command{
@@ -30,7 +29,7 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	RootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	RootCmd.PersistentFlags().BoolVarP(&util.Verbose, "verbose", "v", false, "verbose output")
 	RootCmd.PersistentFlags().StringVarP(&App, "app", "a", "", "application name (defaults to CWD)")
 	RootCmd.PersistentFlags().StringP("filename", "f", "", "config filename (defaults to .ranch.yaml)")
 	RootCmd.SilenceUsage = true

--- a/cmd/ranch/util/common.go
+++ b/cmd/ranch/util/common.go
@@ -16,3 +16,5 @@ func jsonClient() *gorequest.SuperAgent {
 		Set("Accept", "application/json").
 		Set("Content-Type", "application/json")
 }
+
+var Verbose bool

--- a/cmd/ranch/util/docker.go
+++ b/cmd/ranch/util/docker.go
@@ -1,15 +1,19 @@
 package util
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/fsouza/go-dockerclient"
 	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/heroku/docker-registry-client/registry"
 	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/viper"
@@ -37,7 +41,21 @@ func dockerRegistryClient() (*registry.Registry, error) {
 	username := viper.GetString("docker.registry.username")
 	password := viper.GetString("docker.registry.password")
 
-	return registry.New(u, username, password)
+	url := strings.TrimSuffix(u, "/")
+	transport := registry.WrapTransport(http.DefaultTransport, url, username, password)
+	r := &registry.Registry{
+		URL: url,
+		Client: &http.Client{
+			Transport: transport,
+		},
+		Logf: registry.Quiet,
+	}
+
+	if err := r.Ping(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }
 
 func DockerResolveImageName(imageName string) (string, error) {
@@ -112,7 +130,7 @@ func DockerPull(imageNameWithTag string) error {
 		return err
 	}
 
-	silencer := NewDockerSilencer()
+	silencer := newDockerSilencer()
 
 	opts := docker.PullImageOptions{
 		Repository:    absoluteImageName,
@@ -121,32 +139,32 @@ func DockerPull(imageNameWithTag string) error {
 		RawJSONStream: true,
 	}
 
-	fmt.Printf("Pulling docker image %q:", absoluteImageName)
+	fmt.Printf("🐮  Pulling docker image `%s:%s'... ", absoluteImageName, tag)
 
 	if err = client.PullImage(opts, registryAuth()); err != nil {
-		fmt.Println("ERROR")
+		fmt.Println("✘")
 		return err
 	}
 
 	if err = silencer.Finalize(); err != nil {
-		fmt.Println("ERROR")
+		fmt.Println("✘")
 		return err
 	}
 
-	fmt.Println("DONE")
+	fmt.Println("✔")
 	return nil
 }
 
-type DockerSilencer struct {
+type dockerSilencer struct {
 	r   *io.PipeReader
 	w   *io.PipeWriter
 	res chan error
 }
 
-func NewDockerSilencer() *DockerSilencer {
+func newDockerSilencer() *dockerSilencer {
 	r, w := io.Pipe()
 	res := make(chan error)
-	h := DockerSilencer{r, w, res}
+	h := dockerSilencer{r, w, res}
 
 	go func() {
 		dec := json.NewDecoder(r)
@@ -158,9 +176,19 @@ func NewDockerSilencer() *DockerSilencer {
 			} else if err != nil {
 				h.res <- err
 				break
+			}
+
+			if Verbose && m.Stream != "" {
+				fmt.Print(m.Stream)
+			} else if Verbose && m.Progress != "" {
+				fmt.Printf("%s %s\r", m.Status, m.Progress)
 			} else if m.Error != "" {
 				h.res <- errors.New(m.Error)
 				break
+			}
+
+			if Verbose && m.Status != "" {
+				fmt.Println(m.Status)
 			}
 		}
 	}()
@@ -168,13 +196,12 @@ func NewDockerSilencer() *DockerSilencer {
 	return &h
 }
 
-func (h *DockerSilencer) Writer() *io.PipeWriter {
+func (h *dockerSilencer) Writer() *io.PipeWriter {
 	return h.w
 }
 
-func (h *DockerSilencer) Finalize() error {
+func (h *dockerSilencer) Finalize() error {
 	h.w.Close()
-	close(h.res)
 	return <-h.res
 }
 
@@ -194,7 +221,7 @@ func DockerPush(imageNameWithTag string) error {
 		return err
 	}
 
-	silencer := NewDockerSilencer()
+	silencer := newDockerSilencer()
 
 	opts := docker.PushImageOptions{
 		Name:          absoluteImageName,
@@ -203,19 +230,19 @@ func DockerPush(imageNameWithTag string) error {
 		RawJSONStream: true,
 	}
 
-	fmt.Printf("Pushing docker image %s: ", absoluteImageName)
+	fmt.Printf("🐮  Pushing docker image %s:%s... ", absoluteImageName, tag)
 
 	if err = client.PushImage(opts, registryAuth()); err != nil {
-		fmt.Println("ERROR")
+		fmt.Println("✘")
 		return err
 	}
 
 	if err = silencer.Finalize(); err != nil {
-		fmt.Println("ERROR")
+		fmt.Println("✘")
 		return err
 	}
 
-	fmt.Println("DONE")
+	fmt.Println("✔")
 	return nil
 }
 
@@ -243,7 +270,15 @@ func DockerTag(imageName, tag string) error {
 		Tag:  tag,
 	}
 
-	return client.TagImage(absoluteImageName, opts)
+	fmt.Printf("🐮  Tagging docker image %s as %s... ", absoluteImageName, tag)
+
+	if err = client.TagImage(absoluteImageName, opts); err != nil {
+		fmt.Println("✘")
+		return err
+	}
+
+	fmt.Println("✔")
+	return nil
 }
 
 func DockerBuild(appDir string, imageName string, buildEnv map[string]string) error {
@@ -265,12 +300,23 @@ func DockerBuild(appDir string, imageName string, buildEnv map[string]string) er
 		return err
 	}
 
+	r, w := io.Pipe()
+
+	go func() {
+		stripColors := regexp.MustCompile("\\x1b\\[[0-9;]*[mG]")
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			text := scanner.Text()
+			fmt.Printf("%s %s\n", color.WhiteString("docker build |"), stripColors.ReplaceAllString(text, ""))
+		}
+	}()
+
 	buildArgs := make([]docker.BuildArg, 1)
 	buildArgs[0] = docker.BuildArg{Name: "RANCH_BUILD_ENV", Value: string(jsonEnvStr)}
 
 	opts := docker.BuildImageOptions{
 		Name:         absoluteImageName,
-		OutputStream: os.Stdout,
+		OutputStream: w,
 		ContextDir:   appDir,
 		Pull:         true,
 		BuildArgs:    buildArgs,

--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -440,7 +440,7 @@ func RanchDeploy(appDir string, config *RanchConfig, appSha, codeSha string) (er
 	if err != nil {
 		return err
 	} else if exists {
-		fmt.Printf("%s docker image already exists in registry, skipping build.\n", imageNameWithTag)
+		fmt.Printf("🐮  Docker image %s already exists, skipping build.\n", imageNameWithTag)
 	} else {
 		currentSha, err := GitCurrentSha(appDir)
 		if err != nil {
@@ -471,26 +471,17 @@ func RanchDeploy(appDir string, config *RanchConfig, appSha, codeSha string) (er
 		}
 
 		if currentRelease != releaseId {
-			fmt.Printf("promoting existing release %s\n", releaseId)
 			if err = ConvoxPromote(config.AppName, releaseId); err != nil {
 				return err
 			}
-
-			time.Sleep(10 * time.Second) // wait for promote to apply
-
-			if err = ConvoxWaitForStatus(config.AppName, "running"); err != nil {
-				return err
-			}
 		} else {
-			fmt.Printf("existing release %s is currently live, skipping promote.\n", releaseId)
+			fmt.Printf("🐮  Existing release %s is currently active, skipping promote.\n", releaseId)
 		}
 	} else {
 		buildDir, err := ioutil.TempDir("", "ranch")
 		if err != nil {
 			return err
 		}
-
-		fmt.Println("using build directory", buildDir)
 
 		dockerComposeContent, err := GenerateDockerCompose(imageNameWithTag, config)
 		if err != nil {
@@ -522,19 +513,7 @@ func convoxDeploy(appName, releaseId, buildDir string) error {
 		return err
 	}
 
-	fmt.Printf("promoting release %s\n", releaseId)
-
-	if err = ConvoxPromote(appName, releaseId); err != nil {
-		return err
-	}
-
-	time.Sleep(10 * time.Second) // wait for promote to apply
-
-	if err = ConvoxWaitForStatus(appName, "running"); err != nil {
-		return err
-	}
-
-	return nil
+	return ConvoxPromote(appName, releaseId)
 }
 
 // see https://github.com/convox/rack/pull/1044


### PR DESCRIPTION
docker and convox are super chatty and fairly irrelevant to folks not debugging an infrastructure bug.  as such, here's a first pass at cleaning up the logs during a `ranch deploy`.  if you want to see the full chatty thing for debugging, `ranch deploy -v` is your friend.
