### PR TITLE
allow apps to opt into downtime deploys

### DIFF
--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -45,6 +45,10 @@ var dockerComposeTemplate = template.Must(template.New("docker-compose").Parse(`
   labels:
     - convox.port.443.protocol=https
     - convox.idle.timeout=60
+    {{ if $process.DowntimeDeploy -}}
+    - convox.deployment.minimum=0
+    - convox.deployment.maximum=200
+    {{ end }}
   ports:
     - 443:3000
   {{ end }}
@@ -88,10 +92,11 @@ type RanchConfig struct {
 }
 
 type RanchConfigProcess struct {
-	Command   string `json:"command"`
-	Count     int    `json:"count"`
-	Instances int    `json:"instances"` // deprecated
-	Memory    int    `json:"memory"`
+	Command        string `json:"command"`
+	Count          int    `json:"count"`
+	Instances      int    `json:"instances"` // deprecated
+	Memory         int    `json:"memory"`
+	DowntimeDeploy bool   `json:"downtime_deploy"`
 }
 
 type RanchFormationEntry struct {


### PR DESCRIPTION
by adding `downtime_deploy: true` to your process' options, deploys will simultaneously stop the old processes and start the new ones, trading uptime for speed.

(we used to disable preboot on our staging apps in Heroku, and this is the equivalent)

```
name: myapp
processes:
  web:
    downtime_deploy: true
    command: node server.js
    count: 1
    memory: 256
```
