### PR TITLE
Don't set deprecated `domains` property in `.ranch.yaml` when using `ranch init`.

### DIFF
--- a/cmd/ranch/cmd/init.go
+++ b/cmd/ranch/cmd/init.go
@@ -20,8 +20,6 @@ processes:
     command: node server.js
     count: 2
     memory: 256
-    domains:
-      - {{.AppName}}
 `
 
 type yamlTemplateVars struct {


### PR DESCRIPTION
This property is not used, so don't set it via `ranch init`.