### PR TITLE
Remove ambiguity when several config files exist

### DIFF
--- a/cmd/ranch/README.md
+++ b/cmd/ranch/README.md
@@ -21,6 +21,7 @@ $ cd platform/src/github.com/goodeggs
 $ git clone https://github.com/goodeggs/platform.git
 $ cd cmd/ranch
 $ go get ...
+$ go test -v ./...
 ```
 
 Releasing

--- a/cmd/ranch/util/app.go
+++ b/cmd/ranch/util/app.go
@@ -15,7 +15,6 @@ func AppConfigPath(cmd *cobra.Command) (string, error) {
 	configFile, err := cmd.Flags().GetString("filename")
 	
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		return "", err
 	} else {
 		return _appConfigPath(configFile)

--- a/cmd/ranch/util/app.go
+++ b/cmd/ranch/util/app.go
@@ -12,12 +12,36 @@ import (
 )
 
 func AppConfigPath(cmd *cobra.Command) (string, error) {
-	if configFile, err := cmd.Flags().GetString("filename"); err == nil && configFile != "" {
+	configFile, err := cmd.Flags().GetString("filename")
+	
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return "", err
+	} else {
+		return _appConfigPath(configFile)
+	}
+}
+
+func _appConfigPath(configFile string) (string, error) {
+	// use specified config file
+	if configFile != "" {
 		fmt.Printf("using config file %s\n", configFile)
 		return filepath.EvalSymlinks(configFile)
 	}
+	
+	// No filename was specified, scan for .ranch.*.yaml files
+	files, err := filepath.Glob(".ranch.*.yaml")
 
-	return filepath.EvalSymlinks(".ranch.yaml")
+	if err != nil {
+		// scanning directory failed
+		return "", fmt.Errorf("failed to scan directory for .ranch.*.yaml files")
+	} else if len(files) >= 2 {
+		// too many .ranch.*.yaml files exist, we don't want to be ambiguous!
+		return "", fmt.Errorf("Multiple .ranch.*.yaml files exist, specify -f")
+	} else {
+		// fallback to default .ranch.yaml file
+		return filepath.EvalSymlinks(".ranch.yaml")
+	}
 }
 
 func LoadAppConfig(cmd *cobra.Command) (*RanchConfig, error) {
@@ -79,13 +103,31 @@ func AppVersion(cmd *cobra.Command) (string, error) {
 }
 
 func AppName(cmd *cobra.Command) (string, error) {
-	// use flag
-	if app := cmd.Flag("app").Value.String(); app != "" {
+	app := cmd.Flag("app").Value.String()
+	return _appName(app, cmd)
+}
+
+func _appName(app string, cmd *cobra.Command) (string, error) {
+	// use specified app name
+	if app != "" {
+		fmt.Printf("using app name %s\n", app)
 		return app, nil
 	}
 
-	// fall back to config
-	if config, err := LoadAppConfig(cmd); err == nil {
+	// No app name was specified, scan for .ranch.*.yaml files
+	files, err := filepath.Glob(".ranch.*.yaml")
+
+	if err != nil {
+		// scanning directory failed
+		return "", fmt.Errorf("failed to scan directory for .ranch.*.yaml files")
+	} else if len(files) >= 2 {
+		// too many .ranch.*.yaml files exist, we don't want to be ambiguous!
+		return "", fmt.Errorf("Multiple .ranch.*.yaml files exist, specify -a")
+	}
+
+	// fall back to config from .ranch.yaml
+	config, err := LoadAppConfig(cmd)
+	if err == nil {
 		return config.AppName, nil
 	}
 

--- a/cmd/ranch/util/app_AppConfigPath_test.go
+++ b/cmd/ranch/util/app_AppConfigPath_test.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"testing"
+	"os"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type AppConfigPathTestSuite struct {
+	suite.Suite
+}
+
+func (suite *AppConfigPathTestSuite) SetupSuite() {
+	removeTestFiles()
+}
+
+func (suite *AppConfigPathTestSuite) TestRun() {
+	assert := assert.New(suite.T())
+
+	// create .ranch.yaml file if it 
+	os.Create(TEST_RANCHY)
+
+	// test case: no config file passed, attempt to use .ranch.yaml of cwd
+	file, err := _appConfigPath("")
+	assert.Equal(TEST_RANCHY, file, "file returned should be '.ranch.yaml'")
+	assert.Nil(err)
+
+	// test case: no config file passed, scans cwd for .ranch.*.yaml, finds one,
+	// so doesn't require you to specify -f
+	os.Create(TEST_FILE_1)
+	file, err = _appConfigPath("")
+	assert.Equal(TEST_RANCHY, file, "file returned should be '.ranch.yaml'")
+	assert.Nil(err)
+
+	// test case: no config file passed, scans cwd for .ranch.*.yaml, finds two,
+	// so then should error
+	os.Create(TEST_FILE_2)
+
+	file, err = _appConfigPath("")
+	assert.Equal("", file)
+	assert.Error(err, "should complain about multiple ranch configs")
+
+	// test case: filename flat is provided
+	file, err = _appConfigPath(TEST_FILE_1)
+	assert.Equal(TEST_FILE_1, file, "returned file should be test file 1")
+	assert.Nil(err)
+}
+
+func (suite *AppConfigPathTestSuite) TestTearDown() {
+	removeTestFiles()
+}
+
+func TestAppConfigPathTestSuite(t *testing.T) {
+	suite.Run(t, new(AppConfigPathTestSuite))
+}

--- a/cmd/ranch/util/app_AppDir_test.go
+++ b/cmd/ranch/util/app_AppDir_test.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	
+	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+type AppDirTestSuite struct {
+	suite.Suite
+}
+
+func (suite *AppDirTestSuite) TestRun() {
+	assert := assert.New(suite.T())
+
+	// create a junk cobra command for testing
+	var testCmd = cobra.Command{
+		Use: "junk",
+	}
+
+	// TODO: this needs some better coverage, might need to stub out the file system
+	_, err := AppDir(&testCmd)
+	assert.Nil(err)
+}
+
+func TestAppDirTestSuite(t *testing.T) {
+	suite.Run(t, new(AppDirTestSuite))
+}

--- a/cmd/ranch/util/app_AppName_test.go
+++ b/cmd/ranch/util/app_AppName_test.go
@@ -1,0 +1,93 @@
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	
+	"github.com/goodeggs/platform/cmd/ranch/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+type AppNameTestSuite struct {
+	suite.Suite
+}
+
+func (suite *AppNameTestSuite) SetupSuite() {
+	removeTestFiles()
+}
+
+func (suite *AppNameTestSuite) TestRun() {
+	assert := assert.New(suite.T())
+
+	// create a junk cobra command for testing
+	var testCmd = cobra.Command{
+		Use: "junk",
+	}
+	testCmd.Flags().StringP("filename", "f", "", "config filename (defaults to .ranch.yaml)")
+
+	// get current directory name
+	// currentDirectory := "util"
+	wd, err := os.Getwd()
+	assert.Nil(err)
+	currentDirectory := path.Base(wd)
+
+	// test case: use specified app name, regardless of what files exist
+	testAppName := "superuberfantastic"
+	name, err := _appName(testAppName, &testCmd)
+	assert.Equal(testAppName, name, "app name should match specified value")
+	assert.Nil(err)
+
+	// test case: .ranch.yaml file does not exist, so use the directory name
+	name, err = _appName("", &testCmd)
+	assert.Equal(currentDirectory, name, "app name should use directory name")
+	assert.Nil(err)
+
+	// create .ranch.yaml file if it 
+	os.Create(TEST_RANCHY)
+
+	// test case: no app name specified, should use what is inside .ranch.yaml
+	name, err = _appName("", &testCmd)
+	assert.Equal("", name, "app name should use directory name when .ranch.yaml is useless")
+	assert.Nil(err)
+
+	// Note: this is basically doing a brief test of LoadAppConfig
+	value := "name: fantastic\n"
+	err = ioutil.WriteFile(TEST_RANCHY, []byte(value), 0644)
+	assert.Nil(err)
+
+	// test case: .ranch.yaml file specifies an app name, use that
+	name, err = _appName("", &testCmd)
+	assert.Equal("fantastic", name, "app name should use directory name when .ranch.yaml is useless")
+	assert.Nil(err)
+
+	// test case: no config file passed, scans cwd for .ranch.*.yaml, finds one,
+	// so doesn't require you to specify -f
+	os.Create(TEST_FILE_1)
+	name, err = _appName("", &testCmd)
+	assert.Equal("fantastic", name, "file returned should be '.ranch.yaml'")
+	assert.Nil(err)
+
+	// test case: no config file passed, scans cwd for .ranch.*.yaml, finds two,
+	// so then should error
+	os.Create(TEST_FILE_2)
+	name, err = _appName("", &testCmd)
+	assert.Equal("", name)
+	assert.Error(err, "should complain about multiple ranch configs")
+
+	// test case: app name is provided, use even when configs exist
+	name, err = _appName(testAppName, &testCmd)
+	assert.Equal(testAppName, name, "returned file should be test file 1")
+	assert.Nil(err)
+}
+
+func (suite *AppNameTestSuite) TestTearDown() {
+	removeTestFiles()
+}
+
+func TestAppNameTestSuite(t *testing.T) {
+	suite.Run(t, new(AppNameTestSuite))
+}

--- a/cmd/ranch/util/test_utils.go
+++ b/cmd/ranch/util/test_utils.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"os"
+)
+
+const TEST_RANCHY = ".ranch.yaml"
+const TEST_FILE_1 = ".ranch.test1.yaml"
+const TEST_FILE_2 = ".ranch.test2.yaml"
+
+func fileExists(path string) (bool) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	} else {
+		// this isn't actually always false, there might have been an error
+		// reading the file system, permission erorr, who knows...
+		return false
+	}
+}
+
+func removeFileIfExists(path string) {
+	if fileExists(path) {
+		os.Remove(path)
+	}
+}
+
+func removeTestFiles() {
+	// make sure files do not exist
+	removeFileIfExists(TEST_RANCHY)
+	removeFileIfExists(TEST_FILE_1)
+	removeFileIfExists(TEST_FILE_2)
+}


### PR DESCRIPTION
This makes ranch look at the current working directory for existing ranch configuration files. When several exist, it will short-circuit and spits an error to the user that they must specify the configuration they desire using --app and/or --filename (-a / -f respectively) arguments.

Resolves #138289851