### PR TITLE
env and build

### DIFF
--- a/cmd/ranch/cmd/build.go
+++ b/cmd/ranch/cmd/build.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/goodeggs/platform/cmd/ranch/util"
+	"github.com/spf13/cobra"
+)
+
+var buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build the application",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+		config, err := util.LoadAppConfig(cmd)
+		if err != nil {
+			return err
+		}
+
+		appDir, err := util.AppDir(cmd)
+		if err != nil {
+			return err
+		}
+
+		appConfigPath, err := util.AppConfigPath(cmd)
+		if err != nil {
+			return err
+		}
+
+		isClean, err := util.GitFileIsClean(appDir, appConfigPath)
+		if err != nil {
+			return err
+		}
+		if !isClean {
+			return fmt.Errorf("your ranch config file %s must be committed before deploying.", appConfigPath)
+		}
+
+		appSha, err := util.GitCurrentSha(appDir)
+		if err != nil {
+			return err
+		}
+
+		return util.DockerBuildAndPush(appDir, config.ImageName, appSha, config)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(buildCmd)
+}

--- a/cmd/ranch/cmd/deploy.go
+++ b/cmd/ranch/cmd/deploy.go
@@ -22,13 +22,6 @@ var deployCmd = &cobra.Command{
 			return err
 		}
 
-		if errors := util.RanchValidateConfig(config); len(errors) > 0 {
-			for _, err := range errors {
-				fmt.Println(err.Error())
-			}
-			return fmt.Errorf(".ranch.yaml did not validate")
-		}
-
 		appConfigPath, err := util.AppConfigPath(cmd)
 		if err != nil {
 			return err

--- a/cmd/ranch/cmd/deploy_conf.go
+++ b/cmd/ranch/cmd/deploy_conf.go
@@ -17,13 +17,6 @@ var deployConfCmd = &cobra.Command{
 			return err
 		}
 
-		if errors := util.RanchValidateConfig(config); len(errors) > 0 {
-			for _, err := range errors {
-				fmt.Println(err.Error())
-			}
-			return fmt.Errorf(".ranch.yaml did not validate")
-		}
-
 		appConfigPath, err := util.AppConfigPath(cmd)
 		if err != nil {
 			return err

--- a/cmd/ranch/cmd/env.go
+++ b/cmd/ranch/cmd/env.go
@@ -18,21 +18,7 @@ var envCmd = &cobra.Command{
 			return err
 		}
 
-		appName, err := util.AppName(cmd)
-		if err != nil {
-			return err
-		}
-
-		if config.EnvId == "" {
-			return fmt.Errorf("your config does not contain an env_id")
-		}
-
-		plaintext, err := util.RanchGetSecret(appName, config.EnvId)
-		if err != nil {
-			return err
-		}
-
-		env, err := util.ParseEnv(plaintext)
+		env, err := util.RanchGetEnv(config)
 		if err != nil {
 			return err
 		}

--- a/cmd/ranch/cmd/env_set.go
+++ b/cmd/ranch/cmd/env_set.go
@@ -49,6 +49,10 @@ var envSetCmd = &cobra.Command{
 			return err
 		}
 
+		if len(config.Env) > 0 {
+			return fmt.Errorf("env:set is deprecated")
+		}
+
 		appName, err := util.AppName(cmd)
 		if err != nil {
 			return err

--- a/cmd/ranch/cmd/env_unset.go
+++ b/cmd/ranch/cmd/env_unset.go
@@ -50,6 +50,10 @@ var envUnsetCmd = &cobra.Command{
 			return err
 		}
 
+		if len(config.Env) > 0 {
+			return fmt.Errorf("env:unset is deprecated")
+		}
+
 		appName, err := util.AppName(cmd)
 		if err != nil {
 			return err

--- a/cmd/ranch/cmd/init.go
+++ b/cmd/ranch/cmd/init.go
@@ -62,19 +62,8 @@ var initCmd = &cobra.Command{
 
 		fmt.Println("generated .ranch.yaml -- check it now!")
 
-		config, err := util.LoadAppConfig(cmd)
-		if err != nil {
-			return err
-		}
-
-		if errors := util.RanchValidateConfig(config); len(errors) > 0 {
-			for _, err := range errors {
-				fmt.Println(err.Error())
-			}
-			return fmt.Errorf(".ranch.yaml did not validate")
-		}
-
-		return nil
+		_, err = util.LoadAppConfig(cmd)
+		return err
 	},
 }
 

--- a/cmd/ranch/cmd/lint.go
+++ b/cmd/ranch/cmd/lint.go
@@ -11,22 +11,12 @@ var lintCmd = &cobra.Command{
 	Use:   "lint",
 	Short: "Lint a ranch config",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		config, err := util.LoadAppConfig(cmd)
-		if err != nil {
+		if _, err := util.LoadAppConfig(cmd); err != nil {
 			return err
 		}
 
-		errs := util.RanchValidateConfig(config)
-
-		if len(errs) == 0 {
-			fmt.Println("valid")
-			return nil
-		}
-
-		for _, err := range errs {
-			fmt.Println(err.Error())
-		}
-		return fmt.Errorf("ranch config had errors")
+		fmt.Println("valid")
+		return nil
 	},
 }
 

--- a/cmd/ranch/release.sh
+++ b/cmd/ranch/release.sh
@@ -17,8 +17,8 @@ go get github.com/tcnksm/ghr
 gox -osarch "darwin/amd64 linux/amd64" -ldflags "-X main.VERSION=$version" -output "releases/$version/{{.OS}}_{{.Arch}}/ranch"
 
 rm -rf "releases/$version/dist" && mkdir -p "releases/$version/dist"
-( cd "releases/$version/darwin_amd64" && zip "../dist/ranch_${version}_darwin_amd64.zip" ranch )
-( cd "releases/$version/linux_amd64" && tar czvf "../dist/ranch_${version}_linux_amd64.tar.gz" ranch )
+cp "releases/$version/darwin_amd64/ranch" "releases/$version/dist/ranch-Darwin-x86_64"
+cp "releases/$version/linux_amd64/ranch" "releases/$version/dist/ranch-Linux-x86_64"
 
 echo "releasing v${version}..."
 
@@ -38,7 +38,7 @@ go-selfupdate releases/${version}/bins/ ${version}
 echo "syncing ranch-updates S3 bucket"
 aws-vault exec prod -- aws s3 sync --acl public-read public/ s3://ranch-updates.goodeggs.com/stable/ranch/
 
-sha=$(shasum -a 256 releases/${version}/dist/ranch_${version}_darwin_amd64.zip | awk '{print $1}')
+sha=$(shasum -a 256 releases/${version}/dist/ranch-Darwin-x86_64 | awk '{print $1}')
 
 cat <<-EOF
 


### PR DESCRIPTION
I'm still playing with it, but ranch now supports specifying `env` directly in the ranchfile.  It's assumed you're encrypting this file with `git-crypt` or some other solution, but that's not enforced by ranch itself.  (I'm trying this out with Ecru)

Additionally, this adds a new `ranch build` command, which will build and push the Docker image for your app.  I plan to use this to move the garbanzo docker build into Travis.  (I'm testing it on Ecru first)
