### PR TITLE
Update Convox/ECS AMI for better memory management

### DIFF
--- a/ami/.travis/script
+++ b/ami/.travis/script
@@ -15,7 +15,7 @@ else
   aws_env="dev"
 fi
 
-version="${TRAVIS_BRANCH}@$(echo $TRAVIS_COMMIT | cut -c 1-7)"
+version="${TRAVIS_BRANCH}@$(echo $TRAVIS_COMMIT | cut -c 1-7 | sed 's/#//g')"
 
 /tmp/packer/packer build -var="env=$aws_env" -var="version=$version" -var-file="variables.${aws_env}.json" packer.json
 

--- a/ami/.travis/script
+++ b/ami/.travis/script
@@ -15,7 +15,7 @@ else
   aws_env="dev"
 fi
 
-version="${TRAVIS_BRANCH}@$(echo $TRAVIS_COMMIT | cut -c 1-7 | sed 's/#//g')"
+version="$(echo ${TRAVIS_BRANCH} | sed 's/#//g')@$(echo $TRAVIS_COMMIT | cut -c 1-7 )"
 
 /tmp/packer/packer build -var="env=$aws_env" -var="version=$version" -var-file="variables.${aws_env}.json" packer.json
 

--- a/ami/packer.json
+++ b/ami/packer.json
@@ -102,6 +102,9 @@
         "sudo service docker stop",
         "sudo rm -rf /var/lib/docker",
 
+        "echo '# Setting Swappiness to avoide swap usage unless out of memory condition exists'",
+        "echo 'vm.swappiness=0' | sudo tee -a /etc/sysctl.conf",
+
         "echo '# Detach /dev/xvdcz EBS volume'",
         "chmod +x /home/ec2-user/detach-ebs-volumes.sh",
         "AWS_ACCESS_KEY_ID='{{user `aws_access_key`}}' AWS_SECRET_ACCESS_KEY='{{user `aws_secret_key`}}' AWS_DEFAULT_REGION='{{user `aws_region`}}' AWS_SECURITY_TOKEN='{{user `aws_security_token`}}' /home/ec2-user/detach-ebs-volumes.sh",
@@ -154,7 +157,10 @@
         "sudo chmod 0600 /etc/collectd.conf",
         "sudo mkdir -p /var/lib/collectd",
         "sudo mv {/home/ec2-user,/var/lib/collectd}/memory-available.sh",
-        "sudo chmod 0755 /var/lib/collectd/memory-available.sh"
+        "sudo chmod 0755 /var/lib/collectd/memory-available.sh",
+
+        "echo '# Reserving 1536 MiB Ram for ECS Agent'",
+        "echo 'ECS_RESERVED_MEMORY=1536' | sudo tee -a /etc/ecs/ecs.config"
       ]
     }
   ]

--- a/ami/xenial-ecs/amazon-ecs-agent.service
+++ b/ami/xenial-ecs/amazon-ecs-agent.service
@@ -30,6 +30,7 @@ ExecStart=/usr/bin/docker run --name ecs-agent \
   --env=ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
   --env=ECS_ENGINE_AUTH_TYPE="${ECS_ENGINE_AUTH_TYPE}" \
   --env=ECS_ENGINE_AUTH_DATA="${ECS_ENGINE_AUTH_DATA}" \
+  --env=ECS_RESERVED_MEMORY=1536 \
   --env=ECS_UPDATES_ENABLED="${ECS_UPDATES_ENABLED}" \
   "amazon/amazon-ecs-agent:${ECS_VERSION}"
 ExecStop=/usr/bin/docker stop ecs-agent

--- a/ami/xenial-ecs/packer.json
+++ b/ami/xenial-ecs/packer.json
@@ -52,7 +52,8 @@
 
         "sudo apt-get -y update",
         "sudo apt-get -y dist-upgrade",
-
+        "echo '# Setting Swappiness to avoide swap usage unless out of memory condition exists'",
+        "echo 'vm.swappiness=0' | sudo tee -a /etc/sysctl.conf",
         "echo '# Docker'",
         "curl -fsSL https://yum.dockerproject.org/gpg | sudo apt-key add -",
         "sudo add-apt-repository \"deb https://apt.dockerproject.org/repo/ ubuntu-$(lsb_release -cs) main\"",


### PR DESCRIPTION
We've disabled vm swappiness by default (0)
to utilize swap only when an out of memory condition
exists

We've reserved a static amount of ram for the ECS agent.