### PR TITLE
add script to cron to disable docker swap

### DIFF
--- a/ami/disable-docker-swap
+++ b/ami/disable-docker-swap
@@ -1,0 +1,2 @@
+# disable docker swap every minute
+* * * * * root /usr/local/bin/disable-docker-swap.sh

--- a/ami/disable-docker-swap.sh
+++ b/ami/disable-docker-swap.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for a in $(find /cgroup/memory/docker -type d | grep -v '/cgroup/memory/docker$'); do
+  cat "$a/memory.limit_in_bytes" > "$a/memory.memsw.limit_in_bytes"
+done

--- a/ami/packer.json
+++ b/ami/packer.json
@@ -94,6 +94,16 @@
       "destination": "/home/ec2-user/detach-ebs-volumes.sh"
     },
     {
+      "type": "file",
+      "source": "disable-docker-swap.sh",
+      "destination": "/home/ec2-user/disable-docker-swap.sh"
+    },
+    {
+      "type": "file",
+      "source": "disable-docker-swap",
+      "destination": "/home/ec2-user/disable-docker-swap"
+    },
+    {
       "type": "shell",
       "inline": [
         "while [ ! -f /run/cloud-init/result.json ]; do echo 'Waiting for cloud-init...'; sleep 10; done",
@@ -160,7 +170,12 @@
         "sudo chmod 0755 /var/lib/collectd/memory-available.sh",
 
         "echo '# Reserving 1536 MiB Ram for ECS Agent'",
-        "echo 'ECS_RESERVED_MEMORY=1536' | sudo tee -a /etc/ecs/ecs.config"
+        "echo 'ECS_RESERVED_MEMORY=1536' | sudo tee -a /etc/ecs/ecs.config",
+
+        "echo '# Set up disable-docker-swap.sh'",
+        "sudo mv {/home/ec2-user,/usr/local/bin}/disable-docker-swap.sh",
+        "sudo chmod 0755 /usr/local/bin/disable-docker-swap.sh",
+        "sudo mv {/home/ec2-user,/etc/cron.d}/disable-docker-swap"
       ]
     }
   ]


### PR DESCRIPTION
By default, Docker allows containers to use 2x their memory limit as swap.  We observed high IO when a container reaches it's limit, which could be a sign of swap usage.  We would expect the Docker OOM killer to terminate the container once it hits its limit, but perhaps there is a timeframe or rounding errors that allow a container to enter swap and stay there for long enough to impact IO wait on the host.

To solve this, we'll run a simple script out of cron every minute.  It iterates all the docker containers on the host and ensures that the value in `/cgroup/memory/<container>/memory.memsw.limit_in_bytes` (the swap limit) matches the value in `/cgroup/memory/<container>/memory.limit_in_bytes` (the memory limit), which disables swap for that container.
