### PR TITLE
Adjusting cgroup settings directly to control tasks

### DIFF
--- a/ami/adjust-cgroup-settings
+++ b/ami/adjust-cgroup-settings
@@ -1,0 +1,2 @@
+# disable docker swap every minute
+* * * * * root /usr/local/bin/adjust-cgroup-settings.sh

--- a/ami/adjust-cgroup-settings.sh
+++ b/ami/adjust-cgroup-settings.sh
@@ -12,7 +12,7 @@ EOF
 )
 
 # Build a list of stuff we DO want to effect
-TARGETS=$(docker ps --no-trunc | grep -v 'CONTAINER' | grep -Ev "$EXCLUDES_PATTERN" | awk '{ print $1; }' | xargs)
+TARGETS=$( docker ps --no-trunc --format '{{.ID}} {{.Image}}' | grep -Ev "$EXCLUDES_PATTERN" | awk '{ print $1; }' | xargs)
 
 # Apply Modifications
 for a in $TARGETS; do

--- a/ami/adjust-cgroup-settings.sh
+++ b/ami/adjust-cgroup-settings.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Exclude containers we don't want effected by limits
+EXCLUDES_PATTERN=$(cat <<'EOF' | xargs | sed 's/ /|/g'
+amazon/amazon-ecs-agent
+goodeggs/logspout-goodeggs
+yelp/docker-custodian
+convox/api
+convox/agent
+goodeggs/ranch-api
+EOF
+)
+
+# Build a list of stuff we DO want to effect
+TARGETS=$(docker ps --no-trunc | grep -v 'CONTAINER' | grep -Ev "$EXCLUDES_PATTERN" | awk '{ print $1; }' | xargs)
+
+# Apply Modifications
+for a in $TARGETS; do
+
+  # Disable swap (set memory and swap to same size)
+  pushd /cgroup/memory/docker/${a}
+  cat "./memory.limit_in_bytes" > "./memory.memsw.limit_in_bytes"
+  popd
+
+  # Limit IOPS for all devices (5 IOPS/Sec to prevent thrashing, reads and writes)
+  pushd /cgroup/blkio/docker/$a
+  DEVICES="$(cat ./blkio.throttle.io_service_bytes  | awk '{print $1;}' | uniq | grep -v Total)"
+  for b in $DEVICES; do
+    echo "${b} 5" > ./blkio.throttle.write_iops_device
+    echo "${b} 5" > ./blkio.throttle.read_iops_device
+  done
+  popd
+done
+
+# No more swap
+swapoff -a

--- a/ami/adjust-cgroup-settings.sh
+++ b/ami/adjust-cgroup-settings.sh
@@ -33,4 +33,4 @@ for a in $TARGETS; do
 done
 
 # No more swap
-swapoff -a
+/sbin/swapoff -a

--- a/ami/disable-docker-swap
+++ b/ami/disable-docker-swap
@@ -1,2 +1,0 @@
-# disable docker swap every minute
-* * * * * root /usr/local/bin/disable-docker-swap.sh

--- a/ami/disable-docker-swap.sh
+++ b/ami/disable-docker-swap.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-for a in $(find /cgroup/memory/docker -type d | grep -v '/cgroup/memory/docker$'); do
-  cat "$a/memory.limit_in_bytes" > "$a/memory.memsw.limit_in_bytes"
-done

--- a/ami/packer.json
+++ b/ami/packer.json
@@ -95,13 +95,13 @@
     },
     {
       "type": "file",
-      "source": "disable-docker-swap.sh",
-      "destination": "/home/ec2-user/disable-docker-swap.sh"
+      "source": "adjust-cgroup-settings.sh",
+      "destination": "/home/ec2-user/adjust-cgroup-settings.sh"
     },
     {
       "type": "file",
-      "source": "disable-docker-swap",
-      "destination": "/home/ec2-user/disable-docker-swap"
+      "source": "adjust-cgroup-settings",
+      "destination": "/home/ec2-user/adjust-cgroup-settings"
     },
     {
       "type": "shell",
@@ -172,11 +172,11 @@
         "echo '# Reserving 1536 MiB Ram for ECS Agent'",
         "echo 'ECS_RESERVED_MEMORY=1536' | sudo tee -a /etc/ecs/ecs.config",
 
-        "echo '# Set up disable-docker-swap.sh'",
-        "sudo mv {/home/ec2-user,/usr/local/bin}/disable-docker-swap.sh",
-        "sudo chmod 0755 /usr/local/bin/disable-docker-swap.sh",
-        "sudo mv {/home/ec2-user,/etc/cron.d}/disable-docker-swap",
-        "sudo chown root:root /etc/cron.d/disable-docker-swap"
+        "echo '# Set up adjust-cgroup-settings.sh'",
+        "sudo mv {/home/ec2-user,/usr/local/bin}/adjust-cgroup-settings.sh",
+        "sudo chmod 0755 /usr/local/bin/adjust-cgroup-settings.sh",
+        "sudo mv {/home/ec2-user,/etc/cron.d}/adjust-cgroup-settings",
+        "sudo chown root:root /etc/cron.d/adjust-cgroup-settings"
       ]
     }
   ]


### PR DESCRIPTION
In an effort to control thrashing (from swap and/or paging)
as nearing and reaching OOM state in containers in ECS tend to do
I've modified our cron task to disable swap on the host, limit
I/O of all containers outside our platform set, and retained
the previous modification of setting the memory = swap (disable swap
usage) in containers