### PR TITLE
Allow overriding cron memory per app and lower the default slightly.

### DIFF
--- a/cmd/ranch/util/convox.go
+++ b/cmd/ranch/util/convox.go
@@ -200,9 +200,9 @@ func ConvoxScale(appName string, config *RanchConfig) (err error) {
 
 	// scale down hidden 'run' process, which is used by ranch run and cron.
 	if existingEntry, ok := existingFormation["run"]; ok {
-		fmt.Printf(" - run count=0 memory=2048 ")
-		if existingEntry.Count != 0 || existingEntry.Memory != 2048 {
-			if err = ConvoxScaleProcess(appName, "run", 0, 2048); err != nil {
+		fmt.Printf(" - run count=0 memory=%d ", config.CronMemory)
+		if existingEntry.Count != 0 || existingEntry.Memory != config.CronMemory {
+			if err = ConvoxScaleProcess(appName, "run", 0, config.CronMemory); err != nil {
 				fmt.Println("✘")
 				return err
 			}

--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -97,17 +97,28 @@ type RanchApiSecret struct {
 }
 
 type RanchConfig struct {
-	AppName   string                        `json:"name"`
-	ImageName string                        `json:"image_name"`
-	EnvId     string                        `json:"env_id"`
-	Env       []string                      `json:"env"`
-	Processes map[string]RanchConfigProcess `json:"processes"`
-	Cron      map[string]string             `json:"cron"`
-	Volumes   []string                      `json:"volumes"`
+	AppName    string                        `json:"name"`
+	ImageName  string                        `json:"image_name"`
+	EnvId      string                        `json:"env_id"`
+	Env        []string                      `json:"env"`
+	Processes  map[string]RanchConfigProcess `json:"processes"`
+	CronMemory int                           `json:"cron_memory"`
+	Cron       map[string]string             `json:"cron"`
+	Volumes    []string                      `json:"volumes"`
+}
+
+func CreateRanchConfig() *RanchConfig {
+	config := new(RanchConfig)
+
+	config.Processes = make(map[string]RanchConfigProcess)
+	config.CronMemory = 2048
+	config.Cron = make(map[string]string)
+
+	return config
 }
 
 func LoadRanchConfig(filename string) (*RanchConfig, error) {
-	var config *RanchConfig
+	config := CreateRanchConfig()
 
 	src, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -117,17 +128,13 @@ func LoadRanchConfig(filename string) (*RanchConfig, error) {
 	if err = yaml.Unmarshal(src, &config); err != nil {
 		return nil, err
 	}
+
 	if config == nil { // empty file edge case
-		config = new(RanchConfig)
+		config = CreateRanchConfig()
 	}
 
-	// initialize possibly nil fields
-	if config.Processes == nil {
-		config.Processes = make(map[string]RanchConfigProcess)
-	}
-
-	if config.Cron == nil {
-		config.Cron = make(map[string]string)
+	if config.ImageName == "" {
+		config.ImageName = config.AppName
 	}
 
 	// fix up deprecations
@@ -137,10 +144,6 @@ func LoadRanchConfig(filename string) (*RanchConfig, error) {
 			proc.Count = proc.Instances
 			config.Processes[name] = proc // write it back to the map
 		}
-	}
-
-	if config.ImageName == "" {
-		config.ImageName = config.AppName
 	}
 
 	if errors := RanchValidateConfig(config); len(errors) > 0 {
@@ -246,6 +249,10 @@ func RanchValidateConfig(config *RanchConfig) (errors []error) {
 		if name == "run" {
 			errors = append(errors, fmt.Errorf("process name 'run' is invalid: 'run' is a reserved process name"))
 		}
+	}
+
+	if config.CronMemory < 4 || config.CronMemory >= 6144 {
+		errors = append(errors, fmt.Errorf("cron memory %d is invalid: must be between 4 and 6144 MB", config.CronMemory))
 	}
 
 	for name, entry := range config.Cron {

--- a/cmd/ranch/util/ranch.go
+++ b/cmd/ranch/util/ranch.go
@@ -111,7 +111,8 @@ func CreateRanchConfig() *RanchConfig {
 	config := new(RanchConfig)
 
 	config.Processes = make(map[string]RanchConfigProcess)
-	config.CronMemory = 2048
+	// latest node versions can use 1741 MB + 35 MB of patriotic buffer
+	config.CronMemory = 1776
 	config.Cron = make(map[string]string)
 
 	return config

--- a/cmd/ranch/util/ranch_test.go
+++ b/cmd/ranch/util/ranch_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,12 +13,71 @@ type RanchTestSuite struct {
 	suite.Suite
 }
 
+func createValidRanchConfig() *RanchConfig {
+	config := CreateRanchConfig()
+	config.AppName = "cool-app"
+	config.ImageName = "cool-app"
+	return config
+}
+
+func (suite *RanchTestSuite) TestRanchLoadRanchConfigDefaultCronMemory() {
+	assert := assert.New(suite.T())
+
+	file, err := ioutil.TempFile(os.TempDir(), "ranch_test")
+	defer os.Remove(file.Name())
+
+	content := `
+name: myapp
+`
+	if _, err := file.Write([]byte(content)); err != nil {
+		assert.Nil(err)
+	}
+
+	config, err := LoadRanchConfig(file.Name())
+	assert.Nil(err)
+	assert.Equal(config.CronMemory, 2048)
+}
+
+func (suite *RanchTestSuite) TestRanchLoadRanchConfigExplicitCronMemory() {
+	assert := assert.New(suite.T())
+
+	file, err := ioutil.TempFile(os.TempDir(), "ranch_test")
+	defer os.Remove(file.Name())
+
+	content := `
+name: myapp
+cron_memory: 4096
+`
+	if _, err := file.Write([]byte(content)); err != nil {
+		assert.Nil(err)
+	}
+
+	config, err := LoadRanchConfig(file.Name())
+	assert.Nil(err)
+	assert.Equal(config.CronMemory, 4096)
+}
+
+func (suite *RanchTestSuite) TestValidateRanchConfigCronMemory() {
+	assert := assert.New(suite.T())
+
+	config := createValidRanchConfig()
+	config.CronMemory = 3
+	errs := RanchValidateConfig(config)
+	assert.NotEmpty(errs)
+
+	config.CronMemory = 6144
+	errs = RanchValidateConfig(config)
+	assert.NotEmpty(errs)
+
+	config.CronMemory = 4096
+	errs = RanchValidateConfig(config)
+	assert.Empty(errs)
+}
+
 func (suite *RanchTestSuite) TestRanchValidateConfigNoCronJobs() {
 	assert := assert.New(suite.T())
-	config := &RanchConfig{
-		AppName:   "hello-world",
-		ImageName: "hello-world",
-	}
+	config := createValidRanchConfig()
+	config.Cron = make(map[string]string)
 	errs := RanchValidateConfig(config)
 	assert.Empty(errs)
 }
@@ -24,16 +85,13 @@ func (suite *RanchTestSuite) TestRanchValidateConfigNoCronJobs() {
 func (suite *RanchTestSuite) TestRanchValidateConfigValidCronJobs() {
 	assert := assert.New(suite.T())
 	crons := map[string]string{
-		"one": "1 * * * ? echo foo",
-		"fifteen": "15 * * * ? echo bar",
-		"every10": "*/10 * * * ? echo bar", // 00,10,20,30,40,50
+		"one":            "1 * * * ? echo foo",
+		"fifteen":        "15 * * * ? echo bar",
+		"every10":        "*/10 * * * ? echo bar", // 00,10,20,30,40,50
 		"every10onthe3s": "3/10 * * * ? echo bar", // 03,13,23,33,43,53
 	}
-	config := &RanchConfig{
-		AppName:   "hello-world",
-		ImageName: "hello-world",
-		Cron:      crons,
-	}
+	config := createValidRanchConfig()
+	config.Cron = crons
 	errs := RanchValidateConfig(config)
 	assert.Empty(errs)
 }
@@ -43,11 +101,8 @@ func (suite *RanchTestSuite) TestRanchValidateConfigOnTooShortCronInterval() {
 	crons := map[string]string{
 		"foobar": "* * * * ? echo too short",
 	}
-	config := &RanchConfig{
-		AppName:   "hello-world",
-		ImageName: "hello-world",
-		Cron:      crons,
-	}
+	config := createValidRanchConfig()
+	config.Cron = crons
 	errs := RanchValidateConfig(config)
 	assert.NotEmpty(errs)
 }

--- a/cmd/ranch/util/ranch_test.go
+++ b/cmd/ranch/util/ranch_test.go
@@ -35,7 +35,7 @@ name: myapp
 
 	config, err := LoadRanchConfig(file.Name())
 	assert.Nil(err)
-	assert.Equal(config.CronMemory, 2048)
+	assert.Equal(config.CronMemory, 1776)
 }
 
 func (suite *RanchTestSuite) TestRanchLoadRanchConfigExplicitCronMemory() {


### PR DESCRIPTION
- also lower the default to 1766 MB (latest node versions can use 1741 MB + 35 MB of patriotic buffer)
- also extracted parameter defaulting out of  `LoadRanchConfig` to make testing easier

To override the memory limit for all cron jobs in your app, add `cron_memory: 1024` to the top of your `.ranch.yaml`.

:pear: with @bobzoller

[#145722477]